### PR TITLE
Force add data_backup.parquet in workflow

### DIFF
--- a/.github/workflows/data_collection.yml
+++ b/.github/workflows/data_collection.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           git config --global user.email 'actions@github.com'
           git config --global user.name 'GitHub Actions'
-          git add dashboard/data/data_backup.parquet
+          git add -f dashboard/data/data_backup.parquet
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else


### PR DESCRIPTION
We generally want data folders to be ignored, but this one we want to keep. It is easier to force this one, than to keep track of what should or should not be ignored.