### PR TITLE
Updates to XGBoost functions/plotting functions to work with new XGBoost version

### DIFF
--- a/modeling/toc/toc_model_live_2026.Rmd
+++ b/modeling/toc/toc_model_live_2026.Rmd
@@ -24,7 +24,7 @@ library(glue)
 library(SHAPforxgboost)
 set.seed(123)
 #set version for saving (update when changes are significant)
-version = "20260216"
+version = "20260224"
 
 #### Data setup functions ####
 #load grab sample data function
@@ -96,7 +96,9 @@ sensor_prepped <- sensor_data%>%
   bind_rows(riverbend_cottonwood_sub)%>%
   filter(site %nin% c("archery_virridy", "riverbend_virridy", "cottonwood_virridy"))%>%
   pivot_wider(id_cols = c("site","DT_hourly_round"), names_from = "parameter", values_from = "hourly_median")%>%
-  mutate(Turbidity = if_else(Turbidity == 0, 0.1, Turbidity))%>% #replace 0 turbidity with 0.1 to be able to do turbidity corrections and log transformations
+  mutate(Turbidity = case_when(Turbidity < 0.1 ~ 0.1, #replace 0 turbidity with 0.1 to be able to do turbidity corrections and log transformations
+                               Turbidity > 1000 ~ 1000,
+                               TRUE ~ Turbidity))%>% 
   #remove rows where everything other than site and DT_round are NA
   filter(!if_all(-c(site, DT_hourly_round), is.na))%>%
   #applying FDOM temperature & turbidity correcting/standardization
@@ -141,7 +143,8 @@ sensor_lagged <- sensor_prepped %>%
       mutate(sin_doy = sin(2*pi*yday(DT_hourly_round)/365.25), 
              fdom_x_turb = FDOMc * Turbidity, 
              fdom_turb = FDOMc/Turbidity, 
-             fdom_x_sc = FDOMc * `Specific Conductivity`)%>%
+             fdom_x_sc = FDOMc * `Specific Conductivity`, 
+             log_turb = log10(Turbidity))%>%
       # recent variance/sd (sc)
       calc_lagged_parameter(site_col = "site", parameter_col = "Specific Conductivity",
                             dt_col = "DT_hourly_round", lag_fun = "var",
@@ -158,7 +161,7 @@ sensor_lagged <- sensor_prepped %>%
       calc_lagged_parameter(site_col = "site", parameter_col = "Turbidity",
                             dt_col = "DT_hourly_round", lag_fun = "median",
                             time_period = "6 hour", new_value_col = "turb_median_6hour")%>%
-      select(-sc_var_24hr)
+      select(-sc_var_24hr, -log_turb)
     
   })%>%
   bind_rows()
@@ -202,7 +205,8 @@ sensor_final <- sensor_lagged%>%
   mutate(date = as_date(DT_hourly_round))%>%
   left_join(canyon_mouth_flow_daily, by = "date")%>%
   select(-date, -year)%>%
-  rename(DT_round = DT_hourly_round)
+  rename(DT_round = DT_hourly_round)%>%
+  select(-FDOM_final_corr, -FDOM_turb_corr) #not keeping the fully corrected FDOM values since this method might not be effective/correct for our sensors
 
 ```
 
@@ -302,10 +306,10 @@ all_matches_norm <- matchup_results %>%
   # Apply normalization 
   apply_training_scale(
     new_data = .,
-    features = features,
+    features = setdiff(features, "log_turb"),
     full_dataset = sensor_final,
     scaling_param_out_path = paste0("data/derived/model_scaling_parameters/scaling_params_toc_", version)
-  ) %>%
+  )%>%
   na.omit()
 
 # make distribution of all matches normalized features to check for any weird outliers or issues with scaling
@@ -317,6 +321,14 @@ all_matches_norm %>%
   labs(title = "Distribution of Normalized Features in Matchup Dataset", x = "Normalized Value", y = "Count") +
   theme_bw()
 
+#check if any of the features are Inf
+all_matches_norm%>%
+  select(any_of(features))%>%
+  summarise_all(~sum(is.infinite(.)))%>%
+  pivot_longer(everything(), names_to = "feature", values_to = "n_inf")%>%
+  filter(n_inf > 0)
+
+  
 ```
 
 ## Create Holdout Dataset
@@ -547,16 +559,37 @@ First, we will start with our base model (live sensor data only) and then test a
 Here I run the `xgboost_feature_selection()` function which runs a basic xgboost model with the specified features and default hyperparameters. It returns feature importance, shap values, and best iteration info for each fold. We will then look at feature importance and shap values to see which features are most useful, then trim features back to reduce our correlative and overfitting issues. 
 
 ```{r}
-
 # Weighting function for TOC
 toc_high_weights <-  function(df) {
   ifelse(df$TOC <= 4,1,                  # flat weight for low TOC
          1 + 3 *log1p(df$TOC - 4))  # grows slowly, no cap needed
 }
 
+# toc_high_weights_exp <- function(df) {
+#   ifelse(df$TOC <= 4,1,                  # flat weight for low TOC
+#          exp(0.5 * (df$TOC - 4)))  # exponential growth for higher TOC
+# }
+
 #raw sensor features
 general_features <- c("FDOMc","Turbidity","Specific Conductivity", "Temperature")
 
+
+hyper_params <- list(
+  objective        = "reg:squarederror",
+  eval_metric      = "rmse",
+  eta              = 0.05,
+  gamma            = 0.8,
+  alpha            = 0,
+  lambda           = 1,
+  max_depth        = 3,
+  subsample        = 0.5,
+  colsample_bytree = 0.5,
+  min_child_weight  = 2, 
+  nthread = 1)
+```
+
+
+```{r}
 #setup function
 feature_results <- map(
   #list of different features we want to test
@@ -564,8 +597,9 @@ feature_results <- map(
     gen_feat = general_features, 
     fewer_features = c(fewer_features), # this is the set of features we are testing that have been pruned based on correlation and domain knowledge, but still includes flow
     # removing FDOM_turb and turb median 6 hour
-    fewer_features_doy = c(setdiff(fewer_features, c("fdom_turb", "turb_median_6hour"))), 
-    fewest_features = c(setdiff(fewer_features, c("fdom_turb", "turb_median_6hour", "sin_doy")))
+    fewer_features_no_log_turb = c(setdiff(fewer_features, c("fdom_turb", "turb_median_6hour","log_turb"))), 
+    fewer_features_no_doy = c(setdiff(fewer_features, c("fdom_turb", "turb_median_6hour","log_turb", "sin_doy"))),
+    fewest_features = c(setdiff(fewer_features, c("fdom_turb", "turb_median_6hour", "sin_doy", "sc_sd_24hr","log_turb")))
     
   ),
   #Setting function parameters
@@ -577,14 +611,15 @@ feature_results <- map(
       objective        = "reg:squarederror",
       eval_metric      = "rmse",
       eta              = 0.05,
-      gamma            = 0.6,
+      gamma            = 0.8,
       alpha            = 0,
       lambda           = 1,
       max_depth        = 3,
       subsample        = 0.5,
       colsample_bytree = 0.5,
-      min_child_weight  = 2 ), 
-    weight_fun = toc_high_weights
+      min_child_weight  = 2, 
+      nthread = 1), 
+    weight_fun = NULL
   ))
 ```
 
@@ -755,11 +790,7 @@ Now that we have a feature set, we can do some hyperparameter tuning to see if w
 
 ```{r}
 
-folds <- tibble(
-  fold = 1:3,
-  val_ids = list(val_set_1, val_set_2, val_set_3)
- )
-features <- best_models[[1]]$feature_names
+features <- xgb.importance(model = best_models[[1]])$Feature # get features from model to use in tuning)
 
 # Reduce tune grid for reruns (ie. General best params)
 tune_grid = expand.grid(
@@ -781,12 +812,11 @@ tune_grid = expand.grid(
 ```{r}
 set.seed(123)
 hyperp_results <- xgboost_hyperparameter_tuning(
-  data = train_val %>% select(TOC, id, any_of(features)), 
+  train_val_df = train_val %>% select(TOC,fold_id, any_of(features)), 
+  feature_cols = features,
   weights = toc_high_weights,
   tune_grid = tune_grid,
   target_col = "TOC",
-  site_col = "id",
-  fold_ids =  folds, 
   units = "mg/L")
 
 ```
@@ -800,7 +830,7 @@ hyperp_results[[1]]$perf_dist
 hyperp_results[[1]]$eval_plot
 hyperp_results[[1]]$tv_plot
 
-best_fold_1_grid <- 25
+ best_fold_1_grid <- 22
 ```
 Chose the grid `best_fold_1_grid` for fold 1 because it has the lowest validation RMSE, it's RMSE is most closely related to it's val RMSE in the eval plot and doesn't have a evident bench in comparison to other grids. Overall there was minimal difference between grids. 
 
@@ -811,7 +841,7 @@ hyperp_results[[2]]$perf_dist
 hyperp_results[[2]]$eval_plot
 hyperp_results[[2]]$tv_plot
 
-best_fold_2_grid <- 71
+best_fold_2_grid <- 162
 
 ```
 Chose the grid `best_fold_2_grid` for fold 2 because it has the lowest validation RMSE, and there was minimal difference between grids. This fold contains our lowest TOC values in Val which leads to poor performance on the validation set so a bench at both side of the the model is common across grids. 
@@ -823,11 +853,11 @@ hyperp_results[[3]]$perf_dist
 hyperp_results[[3]]$eval_plot
 hyperp_results[[3]]$tv_plot
 
-best_fold_3_grid <- 52
+best_fold_3_grid <- 139
 
 ```
 
-Chose the grid `best_fold_3_grid` for fold 3 because it has the lowest validation RMSE, and the validation points hug the 1:1 line across TOC levels whereas other models appear to deviated to underpredict. 
+Chose the grid `best_fold_3_grid` for fold 3 because it has the second lowest validation RMSE, and the validation points hug the 1:1 line across TOC levels whereas other models appear to deviated to underpredict. 
 
 ```{r}
 
@@ -854,7 +884,7 @@ full_model <- map(1:3, function(i) {
 ```{r}
 importance_list <- lapply(seq_along(full_model), function(i) {
   fold_model <- full_model[[i]]$model
-  features <- fold_model$feature_names
+  features <- xgb.importance(model = fold_model)$Feature
   importance_matrix <- xgb.importance(feature_names = features, model = fold_model)
   importance_df <- as.data.frame(importance_matrix)
   importance_df$Fold <- paste("Fold", i)
@@ -871,7 +901,7 @@ print(importance_list)
 # Function to plot SHAP values for a given fold
 plot_shap <- function(fold_set, training_data, fold_model) {
   #get features from model
-  features <- fold_model$feature_names
+  features <- xgb.importance(model = fold_model)$Feature
   # Predictions on validation/training set
   dtrain <- as.matrix(training_data[, features])
   
@@ -891,7 +921,7 @@ map(1:3, ~ plot_shap(
   fold_model = full_model[[.x]]$model,
   training_data = full_model[[.x]]$training_data
 ))%>%
-  wrap_plots(., ncol = 1, guides = "collect") &
+  wrap_plots(., ncol = 1, axes = "collect", guides = "collect") &
   theme(legend.position = "bottom")
 
 ```
@@ -907,7 +937,7 @@ hyperparam_tv_plots <- map(1:3, ~plot_tv_fold_perf(fold_set = .x,
                                                    target_col = "TOC", units = "mg/L")
 )
 
-hp_tv_plot<- wrap_plots(hyperparam_tv_plots, ncol = 1, guides = "collect")&
+hp_tv_plot<- wrap_plots(hyperparam_tv_plots, ncol = 2, guides = "collect")&
   theme(legend.position = "bottom")
 hp_tv_plot
 ggsave(here(paste0("docs/uclp_dss/figs/realtime_toc_modeling/performance/toc_model_fold_validation_performance_", version, ".png")), width = 14, height = 10)
@@ -944,9 +974,22 @@ If we want to test additional ideas for bias correction or look at model perform
 
 ```{r}
 #commented out so we don't overwrite existing model files
-saveRDS(full_model, file = here("data", "derived", "models","TOC_realtime", "in_dev", paste0("ross_only_toc_xgboost_models_full_",version,".rds")))
-#if we want to reload model
-#full_model <- readRDS(here("data", "derived", "models","TOC_realtime", "in_dev", paste0("ross_only_toc_xgboost_models_full_",version,".rds")))
+
+path <- here("data", "derived", "models","TOC_realtime", "in_dev")
+
+xgb.save(full_model[[1]]$model, fname = file.path(path, paste0("ross_only_toc_xgboost_model_fold1_", version, ".ubj")))
+xgb.save(full_model[[2]]$model, fname = file.path(path, paste0("ross_only_toc_xgboost_model_fold2_", version, ".ubj")))
+xgb.save(full_model[[3]]$model, fname = file.path(path, paste0("ross_only_toc_xgboost_model_fold3_", version, ".ubj")))
+
+#if we want to reload model into full model in the $model slot for each fold index
+full_model <- 1:3 %>%
+  map(~{
+    list(
+      model = xgb.load(file.path(path, paste( "ross_only_toc_xgboost_model_fold", .x, "_", version, ".ubj", sep = ""))),
+      training_data = train_val %>% filter(fold_id != .x),
+      validation_data = train_val %>% filter(fold_id == .x)
+    )
+  })
 
 rm(list = setdiff(ls(), c("train_val", "testing", "full_model","version","id_cols",
                           "sensor_final",
@@ -1004,10 +1047,12 @@ ggsave(here("docs","uclp_dss", "figs", "realtime_toc_modeling","performance",pas
 
 ```{r}
 #loading in all sensor data and applying training scaling
+feats <- xgb.importance(full_model[[1]]$model)$Feature
+
 sensor_ts <- apply_training_scale(new_data = sensor_final, 
                                   full_dataset = sensor_final, 
-                                  features = full_model[[1]]$model$feature_names)%>%
-  select(site, DT_round, any_of(full_model[[1]]$model$feature_names))
+                                  features = feats )%>%
+  select(site, DT_round, any_of(feats))
 
 water_chem <- load_grab_sample_data()
 
@@ -1020,7 +1065,7 @@ time_series_dir <- here("docs", "uclp_dss", "figs", "realtime_toc_modeling", "ti
 
 chd_plot <- plot_model_timeseries(model_input_df = sensor_ts, 
                                   water_chem_df = water_chem, 
-                                  summary_interval = "4 hour",
+                                  summary_interval = "6 hour",
                                   site_sel = "chd", 
                                   site_title = "Chambers Lake outflow",
                                   model = map(full_model, "model"),
@@ -1056,7 +1101,7 @@ ggsave(here(time_series_dir, paste0("chambers_outflow_20250501_20250705_toc", ve
 
 pfal_plot <- plot_model_timeseries(model_input_df = sensor_ts, 
                                    water_chem_df = water_chem%>%filter(collector == "ROSS"), 
-                                   summary_interval = "4 hour",
+                                   summary_interval = "6 hour",
                                    site_sel = "pfal", 
                                    site_title = "Poudre @ Poudre Falls",
                                    model = map(full_model, "model"),
@@ -1297,6 +1342,13 @@ We will extract just the model objects from the list to save space.
 small_models <- map(full_model, "model")
 
 saveRDS(small_models, file = here("data", "derived", "models","TOC_realtime", "in_dev", paste0("ross_only_toc_xgboost_models_light_",version,".rds")))
+
+# Save xgb versions for safety
+xgb.save(small_models[[1]], fname = here("data", "derived", "models","TOC_realtime", "in_dev", paste0("ross_only_toc_xgboost_model_fold1_", version, ".ubj")))
+
+xgb.save(small_models[[2]], fname = here("data", "derived", "models","TOC_realtime", "in_dev", paste0("ross_only_toc_xgboost_model_fold2_", version, ".ubj")))
+
+xgb.save(small_models[[3]], fname = here("data", "derived", "models","TOC_realtime", "in_dev", paste0("ross_only_toc_xgboost_model_fold3_", version, ".ubj")))
 
 ```
 

--- a/src/modeling/xgboost_feature_selection.R
+++ b/src/modeling/xgboost_feature_selection.R
@@ -1,81 +1,66 @@
-#' XGBoost Feature Selection with Cross-Validation and SHAP Values for Regression Target
+#' XGBoost Feature Selection with Cross-Validation and SHAP Values
 #'
-#' Trains XGBoost models across multiple folds to evaluate feature importance
-#' and SHAP values. This function helps identify the most predictive features
-#' by aggregating performance and contribution metrics across data splits.
+#' Trains XGBoost regression models across multiple folds to evaluate feature importance
+#' and SHAP (SHapley Additive exPlanations) values. This function facilitates identifying
+#' the most predictive features by aggregating performance and contribution metrics
+#' across data splits.
 #'
-#' @param train_val_df A data frame or tibble containing features, the target variable (`target_col`),
-#'   and a `fold_id` column used for cross-validation splitting. All rows in `train_val_df` must have a `fold_id` value.
+#' @param train_val_df A data frame or tibble containing predictor features,
+#'   the target variable, and a `fold_id` column used for cross-validation.
+#'   All rows must have a valid `fold_id`.
 #' @param features_to_test A character vector of column names to be used as predictors.
-#' @param target_col A string specifying the name of the response variable.
+#' @param target_col A string specifying the name of the response (target) variable.
 #' @param default_hyper_params A list of hyperparameters to pass to \code{xgb.train}.
-#'   Must include the following: \code{objective}, \code{eval_metric}, \code{eta} for the model to run. Other parameters can be included but are not required.
-#'   If these are not included, defaults will be set to: \code{objective = "reg:squarederror"}, \code{eval_metric = "rmse"} and  \code{eta = 0.05}.
+#'   If missing, the following defaults are used:
+#'   \itemize{
+#'     \item \code{objective = "reg:squarederror"}
+#'     \item \code{eval_metric = "rmse"}
+#'     \item \code{eta = 0.05}
+#'     \item \code{nthread = 1}
+#'   }
 #' @param weight_fun A function that takes a data frame and returns a numeric vector
 #'   of weights. If \code{NULL}, all observations are weighted equally (1).
 #'
-#' @return A list containing:
-#' \itemize{
-#'   \item \code{model}: A list of trained \code{xgb.Booster} objects (one per fold).
-#'   \item \code{features}: The unique vector of features tested.
-#'   \item \code{best_msg}: A tibble of performance metrics (rmse) and best iterations per fold.
-#'   \item \code{model_importance}: A tibble of XGBoost importance metrics (Gain, Cover, Frequency) per fold.
-#'   \item \code{shap_values}: A tibble of mean absolute SHAP values for train and validation sets per fold.
+#' @return A named list containing:
+#' \describe{
+#'   \item{\code{model}}{A list of trained \code{xgb.Booster} objects, one per fold.}
+#'   \item{\code{features}}{The unique vector of features used for training.}
+#'   \item{\code{best_msg}}{A tibble summarizing best iterations and RMSE (train/val) for each fold.}
+#'   \item{\code{model_importance}}{A tibble of XGBoost importance metrics (Gain, Cover, Frequency) for every fold.}
+#'   \item{\code{shap_values}}{A tibble of mean absolute SHAP values for both training and validation sets per fold.}
 #' }
 #'
+#' @export
 #'
 #' @examples
-#' # Setting our default hyperparameters
+#' \dontrun{
+#' # 1. Define hyperparameters
+#' params <- list(
+#'   objective        = "reg:squarederror",
+#'   eta              = 0.05,
+#'   max_depth        = 4,
+#'   subsample        = 0.5,
+#'   colsample_bytree = 0.5
+#' )
 #'
-#'default_hyper_params <- list(
-#'  objective        = "reg:squarederror",
-#'  eval_metric      = "rmse",
-#'  eta              = 0.05,
-#'  gamma            = 0.6,
-#'  alpha            = 0,
-#'  lambda           = 1,
-#'  max_depth        = 4,
-#'  subsample        = 0.5,
-#'  colsample_bytree = 0.5,
-#'  min_child_weight  = 2
-#')
-
-#' # weighting function for TOC categories to emphasize high TOC values
-#' Weighting function for TOC
-#' toc_high_weights <-  function(df) {
-#'  ifelse(df$TOC <= 4,1,                  # flat weight for low TOC
-#'         1 + 3 *log1p(df$TOC - 4))  # grows slowly, no cap needed
-#'}
-
-#' #set aside sensor parameters that are generally useful
-#'general_features <- c("FDOMc","Sensor_Turb","Sensor_Cond", "Chl_a", "Temp")
-#'
-#' #Running function on general features only
-#'
-#'general_feature_results <- xgboost_feature_selection(
-#'  train_val_df = train_val,
-#'  features_to_test = general_features,
-#'  target_col = "TOC_cat",
-#'  default_hyper_params = default_hyper_params,
-#'  weight_fun = high_weight
-#')
-
-#'# Testing multiple feature sets to see if there is improvement
-
-#' feature_results <- map(
-#'  list(
-#'    gen_feat = general_features,
-#'    more_features = c(fewer_features, "sin_doy", "daily_canyon_mouth_flow")
-#'    ),
-#'   ~xgboost_feature_selection(
-#'    train_val_df = train_val,
-#'    features_to_test = .x,
-#'    target_col = "TOC_cat",
-#'    default_hyper_params = default_hyper_params
-#'  )
-#'
+#' # 2. Define a weighting function (optional)
+#' # Emphasize high TOC (Total Organic Carbon) values
+#' toc_weights <- function(df) {
+#'   ifelse(df$TOC <= 4, 1, 1 + 3 * log1p(df$TOC - 4))
 #' }
 #'
+#' # 3. Run feature selection
+#' results <- xgboost_feature_selection(
+#'   train_val_df = train_val,
+#'   features_to_test = c("FDOMc", "Sensor_Turb", "Sensor_Cond", "Temp"),
+#'   target_col = "TOC",
+#'   default_hyper_params = params,
+#'   weight_fun = toc_weights
+#' )
+#'
+#' # 4. Inspect importance
+#' print(results$model_importance)
+#' }
 xgboost_feature_selection <- function(train_val_df,
                                           features_to_test,
                                           target_col,
@@ -106,7 +91,7 @@ xgboost_feature_selection <- function(train_val_df,
   }
   #check that default_hyper_params has an objective, eval metric and eta
   #All other parameters have fine defaults so we can ignore them if a user does not input them
-  required_params <- c("objective", "eval_metric", "eta")
+  required_params <- c("objective", "eval_metric", "eta", "nthread")
 
   if(!all(required_params %in% names(default_hyper_params))){
     missing_params <- required_params[!required_params %in% names(default_hyper_params)]
@@ -121,6 +106,9 @@ xgboost_feature_selection <- function(train_val_df,
     }
     if("eval_metric" %in% missing_params) {
       default_hyper_params$eval_metric <- "rmse"
+    }
+    if("nthread" %in% missing_params) {
+      default_hyper_params$nthread <- 1
     }
   }
 
@@ -148,21 +136,20 @@ xgboost_feature_selection <- function(train_val_df,
   shap_val_df <- tibble(Feature = features_to_test)
   best_msgs <- tibble()
   models <- list()
+  fold_ids <- sort(unique(train_val_df$fold_id), decreasing = FALSE)
 
-  for(i in unique(train_val$fold_id)){
 
+  for(i in fold_ids){
     #train val split
-    train_data <- train_val %>%
+    train_data <- train_val_df %>%
       filter(fold_id != i) %>%
-      select(any_of(c(features_to_test, target, "id", "sensor_datetime", "collector")))
+      select(any_of(c(features_to_test, target_col, "id", "sensor_datetime", "collector")))
 
     val_data <- suppressMessages(
-      train_val %>%
+      train_val_df %>%
         anti_join(train_data)
     )
-    if(is.null(weight_fun)){
-      weight_fun <- function(df) {rep(1, nrow(df))}
-    }
+
     #weight data
     w_train <- weight_fun(train_data)
     w_val   <- weight_fun(val_data)
@@ -170,13 +157,13 @@ xgboost_feature_selection <- function(train_val_df,
     #prep matrices
     dtrain <- xgb.DMatrix(
       data = as.matrix(train_data[, features_to_test]),
-      label = train_data[[target]],
+      label = train_data[[target_col]],
       weight = w_train
     )
 
     dval <- xgb.DMatrix(
       data = as.matrix(val_data[, features_to_test]),
-      label = val_data[[target]],
+      label = val_data[[target_col]],
       weight = w_val
     )
 
@@ -187,32 +174,29 @@ xgboost_feature_selection <- function(train_val_df,
       params = default_hyper_params,
       data = dtrain,
       nrounds = 10000,
-      watchlist = watchlist,
+      evals = watchlist,
       early_stopping_rounds = 1000,
       print_every_n = 1000,
-      verbose = 0,
-      nthread = 1
+      verbose = 0
     )
     #Save model
     models[[i]] <- model
-    #Save best msg
+    #get eval log
+    eval_log <- attributes(model)$evaluation_log
+    #get best iteration
+    best_iter <- as.numeric(xgb.attr(model, "best_iteration"))
+  #Extract best message
     best_msg <- tibble(
       fold_id = i,
-      best_iteration = model$best_iteration,
-      best_msg = model$best_msg
-    ) %>%
-      #clean up message
-      mutate(
-        train_rmse = str_extract(best_msg, "(?<=train-rmse:)\\d+\\.\\d+"),
-        eval_rmse  = str_extract(best_msg, "(?<=eval-rmse:)\\d+\\.\\d+"),
-        train_rmse = as.numeric(train_rmse),
-        eval_rmse  = as.numeric(eval_rmse)
-      )%>%
-      select(-best_msg)
+      best_iteration = best_iter,
+      # We use best_iter + 1 because R is 1-indexed and XGBoost is 0-indexed
+      train_rmse = eval_log$train_rmse[best_iter + 1],
+      eval_rmse  = eval_log$eval_rmse[best_iter + 1]
+    )
+
     #best message
     best_msgs <- bind_rows(best_msgs, best_msg)%>%
       distinct()
-
 
     #Feature importance
     importance_df <- importance_df%>%
@@ -222,16 +206,34 @@ xgboost_feature_selection <- function(train_val_df,
                     .cols = c(Gain, Cover, Frequency)
                   ), by = "Feature")
 
+    train_X <- as.matrix(train_data[, features_to_test])
+    val_X <- as.matrix(val_data[, features_to_test])
+    #In case we need to predict and output a plot of predicted vs actual for train and val
+    # train_data$pred <- predict(model, newdata = train_X)
+    # val_data$pred <- predict(model, newdata = val_X)
+    #
+    # max_val <- max(c(train_data[[target_col]], val_data[[target_col]]), na.rm = TRUE)
+    # min_val <- min(c(train_data[[target_col]], val_data[[target_col]]), na.rm = TRUE)
+    #
+    # ggplot(train_data, aes(x = !!sym(target_col), y = pred )) +
+    #   geom_point() +
+    #   geom_point(data = val_data, aes(x = !!sym(target_col), y = pred), color = "blue") +
+    #   geom_abline(slope = 1, intercept = 0, color = "red") +
+    #   labs(title = glue("Fold {i} - Train: Predicted vs Actual"),
+    #        x = paste0(target_col, " (Actual)"),
+    #        y = paste0(target_col, " (Predicted)")) +
+    #   ylim(min_val,max_val)+
+    #   xlim(min_val,max_val)
     # SHAP (Training)
-    shap_long_train <- shap.prep(xgb_model = model, X_train = as.matrix(train_data[, features_to_test]))
-    shap_vals_train <- shap.values(xgb_model = model, X_train = dtrain)$mean_shap_score %>%
+    shap_long_train <- shap.prep(xgb_model = model, X_train = train_X)
+    shap_vals_train <- shap.values(xgb_model = model, X_train = train_X)$mean_shap_score %>%
       as.data.frame() %>%
       tibble::rownames_to_column("Feature") %>%
       rename(train_mean_abs_shap = ".")
 
     # SHAP (Validation)
-    shap_long_val <- shap.prep(xgb_model = model, X_train = as.matrix(val_data[, features_to_test]))
-    shap_vals_val <- shap.values(xgb_model = model, X_train = dval)$mean_shap_score %>%
+    shap_long_val <- shap.prep(xgb_model = model, X_train = val_X)
+    shap_vals_val <- shap.values(xgb_model = model, X_train = val_X)$mean_shap_score %>%
       as.data.frame() %>%
       tibble::rownames_to_column("Feature") %>%
       rename(val_mean_abs_shap = ".")
@@ -244,7 +246,6 @@ xgboost_feature_selection <- function(train_val_df,
       )
     shap_val_df <- shap_val_df%>%
       left_join(shap_val, by = c("Feature"))
-
   }
 
   #output

--- a/src/modeling/xgboost_hyperparameter_tuning.R
+++ b/src/modeling/xgboost_hyperparameter_tuning.R
@@ -1,55 +1,71 @@
 #' @title XGboost model training with site-stratified hyperparameter tuning
 #'
 #' @description
-#' This script with take in training/validation data, hyper parameters, site info on train/val splits and column info and then train/hypertune XGBoost models using caret
+#' This function trains and tunes XGBoost models across multiple folds.
+#' It handles the splitting of data into training and validation sets based on
+#' a provided fold identifier (`fold_id`), applies a custom weighting scheme (`weights`)if provided,
+#' and evaluates a grid of hyperparameters (`tune_grid`) for each fold.
+#' Performance is evaluated using root mean squared error (RMSE), mean absolute error (MAE),
+#' and bias. The top 10 models based on validation RMSE are identified, and
+#' from those, the 6 models with the smallest gap between training and validation RMSE
+#' are selected as the best performing models to prevent overfitting.
+#' The function returns performance distributions, learning rate evaluations, and
+#' diagnostic plots for the best models.
 #'
-#' @param data Data frame containing the features and target variable. This data should be normalized/standardized already and should not contain any testing data
-#'
+#' @param train_val_df Data frame containing the feature columns, target variable,
+#'   and a `fold_id` column used for cross-validation splitting. The dataset
+#'   should be pre-processed (e.g., standardized to a range of 0-1) and contain no testing data.
+#' @param feature_cols A character vector of column names to be used as predictors.
+#' @param target_col Character string indicating the column name of the target variable
+#'   to be predicted. Default is `"TOC"`.
+#' @param site_col Character string indicating the site identifier column. Default is `"id"`.
 #' @param weights Optional weighting scheme for observations.
 #'   - `NULL`: all observations receive equal weight (default).
-#'   - A numeric vector of length `nrow(data)`: each observation is assigned the
-#'     corresponding weight, which will be subset by fold during training/validation.
+#'   - A numeric vector of length `nrow(data)`: assigns a specific weight to each observation.
 #'   - A function that takes a data.frame and returns a numeric vector of weights.
-#' @param tune_grid expanded grid of hyperparameters to tune over. Please double check with `caret` and `xgboost` packages before inputting hyperparameters.
-#' If NULL, a default grid will be used.
+#' @param tune_grid A data frame containing combinations of hyperparameters to tune over.
+#'   If `NULL`, a default grid is used.
+#' @param units Character string indicating the units of the target parameter, used
+#'   for plot labeling. Default is `"mg/L"`.
 #'
-#' @param target_col Character string indicating column of the target variable to be predicted.
-#'
-#' @param site_col Character string indicating column of the site ids to retrieve data for.
-#'
-#' @param units Character string indicating the units of the target parameter (for plotting purposes only).
-#'
-#' @param fold_ids dataframe containing the fold number and a list of the corresponding validation site ids
-#'
-#' @return A caret model object containing the trained XGBoost model for each fold and performance metrics (train/val RMSE, MAE, Bias).
-#' Best performing models determined by taking the top 10 val RMSE scores and then selecting the one with the smallest train-val gap.
-#'
+#' @return A list of lists (one per fold) containing:
+#' \itemize{
+#'   \item \code{tv_plot}: A combined `ggplot` of the training vs. validation performance for the top 6 models.
+#'   \item \code{eval_plot}: A combined `ggplot` showing the learning curves (eval log) for the top 6 models.
+#'   \item \code{perf_dist}: A `ggplot` histogram showing the distribution of training and validation RMSE across all tested parameter grids.
+#'   \item \code{grid_results}: A sub-list containing the model object, performance metrics, and hyperparameters for each of the top 6 models.
+#' }
 #'
 #' @examples
-#' folds <- tibble(
-#'   fold = 1:4,
-#'   val_ids = list(val_set_1, val_set_2, val_set_3, val_set_4)
-#'  )
+#' \dontrun{
+#' # Assuming `train_val` data frame has a `fold_id` column
+#'
+#' tune_grid <- expand.grid(
+#'   nrounds = 10000,
+#'   max_depth = c(2, 3, 4),
+#'   eta = c(0.005, 0.01, 0.1),
+#'   gamma = c(0.4, 0.6),
+#'   colsample_bytree = c(0.5, 0.8),
+#'   min_child_weight = c(2, 4, 6),
+#'   subsample = c(0.5, 0.8),
+#'   lambda = 1,
+#'   alpha = 0
+#' )
+#'
+#' results <- xgboost_hyperparameter_tuning(
+#'   train_val_df = train_val,
+#'   feature_cols = c("Temp", "Turbidity", "FDOM"),
+#'   target_col = "TOC",
+#'   site_col = "id",
+#'   weights = NULL,
+#'   tune_grid = tune_grid,
+#'   units = "mg/L"
+#' )
+#' }
 
-#' model <- xgboost_site_stratified_tuning(
-#'    data = train_val %>% select(TOC, id, any_of(features)),
-#'    tune_grid = expand.grid(
-#'      nrounds = 10000,
-#'      max_depth = c(2, 3, 4),
-#'      eta = c(0.005, 0.01, 0.1),
-#'      gamma = c(0.6, 0.8),
-#'      colsample_bytree = c(0.5, 0.8),
-#'      min_child_weight = c(2,4, 6),
-#'      subsample = c(0.5, 0.8)
-#'    ),
-#'  target_col = "TOC",
-#'  site_col = "id",
-#' fold_ids =  folds,
-#' units = "mg/L"
-#')
-
-xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "id", weights = NULL,
-                                           tune_grid = NULL, fold_ids, units = "mg/L") {
+xgboost_hyperparameter_tuning <- function(train_val_df, feature_cols, target_col = "TOC", site_col = "id", weights = NULL,
+                                           tune_grid = NULL, units = "mg/L") {
+  source("src/plotting/plot_tv_fold_perf.R") #load plotting function
 
   # Create default grid if not provided
   if (is.null(tune_grid)) {
@@ -60,31 +76,15 @@ xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "
       gamma = c(0.4, 0.6),
       colsample_bytree = c(0.5, 0.8),
       min_child_weight = c(2, 4, 6),
-      subsample = c(0.5, 0.8)
+      subsample = c(0.5, 0.8),
+      lambda = c(1),
+      alpha = c(0)
     )
   }
 
+  fold_ids <- sort(unique(train_val_df$fold_id))
   #Set up the fold indices
-  n_folds <- nrow(fold_ids)
-
-  fold_indices <- list()
-  fold_indices_out <- list()
-
-  # create indices for each fold based on the fold_ids input lists
-  for (i in 1:n_folds) {
-    val_sites <- fold_ids$val_ids[[i]]
-
-    # Indices for validation
-    val_idx <- which(data[[site_col]] %in% val_sites)
-    # Indices for training (complement)
-    train_idx <- setdiff(1:nrow(data), val_idx)
-
-    fold_indices[[i]] <- train_idx
-    fold_indices_out[[i]] <- val_idx
-  }
-
-  # Prepare features
-  features <- setdiff(names(data), c(target_col, site_col))
+  n_folds <- length(fold_ids)
 
   # Train model
   cat("Starting site-stratified hyperparameter tuning...\n")
@@ -97,20 +97,21 @@ xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "
   #val_data_lists <- list()
 
 # Run through each train/val fold and hypertune
-  for (i in seq_along(fold_indices)) {
+  for (i in seq_along(fold_ids)) {
     cat(paste0("Tuning fold ", i, " of ", n_folds, "...\n"))
 
     #setup performance dataframe
     perf <- data.frame()
 
-    # Split data into training and validation sets based on indices above
-    train_idx <- fold_indices[[i]]
-    val_idx   <- fold_indices_out[[i]]
+    # Split data into training and validation sets based on fold id
 
-    train_data <- data[fold_indices[[i]], ]
+    train_data <- train_val_df%>%
+      filter(fold_id != i | is.na(fold_id)) %>%
+      select(-fold_id)
     #train_data_lists[[i]] <- train_data
-    val_data   <- data[fold_indices_out[[i]], ]
-    #val_data_lists[[i]] <- val_data
+    val_data   <- train_val_df %>%
+      filter(fold_id == i & !is.na(fold_id)) %>%
+      select(-fold_id)
 
     # set up weights (if none provided, default to 1)
     if (is.null(weights)) {
@@ -130,13 +131,13 @@ xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "
 
     # set up data matrix for xgb
     dtrain <- xgb.DMatrix(
-      data = as.matrix(train_data[, features]),
+      data = as.matrix(train_data[, feature_cols]),
       label = train_data[[target_col]],
       weight = w_train # add weights
     )
 
     dval <- xgb.DMatrix(
-      data = as.matrix(val_data[, features]),
+      data = as.matrix(val_data[, feature_cols]),
       label = val_data[[target_col]],
       weight = w_val # add weights
     )
@@ -159,7 +160,8 @@ xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "
         max_depth        = tune_grid$max_depth[j],
         subsample        = tune_grid$subsample[j],
         colsample_bytree = tune_grid$colsample_bytree[j],
-        min_child_weight  = tune_grid$min_child_weight[j]
+        min_child_weight  = tune_grid$min_child_weight[j],
+        nthread = 1
       )
       #set seed for reproducibility
       set.seed(123)
@@ -169,21 +171,24 @@ xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "
         params = params,
         data = dtrain,
         nrounds = tune_grid$nrounds[j],
-        watchlist = watchlist,
+        evals = watchlist,
         #change early stopping rounds based on eta (smaller eta, larger rounds)
         early_stopping_rounds = ifelse(tune_grid$eta[j] >= 0.1, 250,
                                        ifelse(tune_grid$eta[j] >= 0.01, 500,
                                               1000)),
         print_every_n = 1000,
-        verbose = 0,
-        nthread = 1
+        verbose = 0
       )
 
       pred_col <- paste0(target_col, "_guess")
+
+      best_iter <- xgb.attr(model_ij, "best_iteration") %>% as.numeric()
+
       # Predictions on validation set
       val_data[[pred_col]] <- predict(
         model_ij, dval,
-        iterationrange = c(1, model_ij$best_iteration)
+        iterationrange = c(1, best_iter),
+        validate_features = TRUE
       )
       rmse_val  <- rmse(val_data[[target_col]], val_data[[pred_col]])
       mae_val   <- mae( val_data[[target_col]], val_data[[pred_col]])
@@ -192,7 +197,8 @@ xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "
       # Predictions on training set (to measure overfitting)
       train_data[[pred_col]] <- predict(
         model_ij, dtrain,
-        iterationrange = c(1, model_ij$best_iteration)
+        iterationrange = c(1, best_iter),
+        validate_features = TRUE
       )
       rmse_train  <- rmse(train_data[[target_col]], train_data[[pred_col]])
       mae_train   <- mae( train_data[[target_col]], train_data[[pred_col]])
@@ -201,7 +207,7 @@ xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "
       perf <- rbind(perf, data.frame(
         fold       = i,
         grid_id    = j,
-        best_iter  = model_ij$best_iteration,  # from early stopping
+        best_iter  = best_iter,  # from early stopping
         rmse_val   = rmse_val,
         mae_val    = mae_val,
         bias_val   = bias_val,
@@ -246,30 +252,30 @@ xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "
       model_key <- paste0("fold", fold_id, "_grid", grid_id)
 
       #Objects for learning rate plot
-      eval_log <- fold_models[[model_key]][["evaluation_log"]]
-      params <- fold_models[[model_key]][["params"]]
+      eval_log <- attributes(fold_models[[model_key]])$evaluation_log
+      params <- attributes(fold_models[[model_key]])$params
       #remove objective, eval metric, validate parameters, tree method, nthread from params
-      params <- params[!names(params) %in% c("objective", "eval_metric", "validate_parameters", "tree_method", "nthread")]
+      params <- params[!names(params) %in% c("objective", "eval_metric", "validate_parameters", "tree_method", "nthread", "seed")]
       # collapse params into a single string
       param_text <- paste(
         names(params), "=", unlist(params),
         collapse = "\n"
       )
       # Get best iteration and corresponding RMSE
-      best_iter <- which.min(eval_log$eval_rmse)
+      best_iter <- xgb.attr(fold_models[[model_key]], "best_iteration") %>% as.numeric()
 
       # Predictions on validation/training set
       #convert train_val sets to matrix for prediction
-      val_matrix <- val_data[, features]%>%
+      val_matrix <- val_data[, feature_cols]%>%
         mutate(across(everything(), as.numeric)) %>%
         as.matrix()
-      train_matrix <- train_data[, features]%>%
+      train_matrix <- train_data[, feature_cols]%>%
         mutate(across(everything(), as.numeric)) %>%
         as.matrix()
       #make predictions
-      val_data[[target_pred_col]] <-  predict(fold_models[[model_key]], val_matrix, iterationrange = c(1, fold_models[[model_key]]$best_iteration))
+      val_data[[target_pred_col]] <-  predict(fold_models[[model_key]], val_matrix, iterationrange = c(1, best_iter), validate_features = T)
       val_data$group <-  "Validation"
-      train_data[[target_pred_col]] <-  predict(fold_models[[model_key]], train_matrix, iterationrange = c(1, fold_models[[model_key]]$best_iteration))
+      train_data[[target_pred_col]] <-  predict(fold_models[[model_key]], train_matrix, iterationrange = c(1, best_iter), validate_features = T)
       train_data$group <-  "Train"
 
       # Calculate RMSE/MAE for annotation
@@ -309,62 +315,10 @@ xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "
       }
 
 
-      # Create performance plot on Train/val
 
-      # Combine train and val sets for plotting
-      plot_data <- bind_rows(train_data, val_data)
-      # get plot bounds
-      min_val <- min(plot_data[[target_col]], na.rm = TRUE)
-      max_val <- max(plot_data[[target_col]], na.rm = TRUE)
-      plot_range <- max_val - min_val
-      box_width <- plot_range * 0.5
-      box_height <- plot_range * 0.2
-      box_xmin <- min_val + plot_range * 0.02
-      box_xmax <- box_xmin + box_width
-      box_ymax <- max_val - plot_range * 0.02
-      box_ymin <- box_ymax - box_height
-      text_x <- (box_xmin + box_xmax) / 2
-      text_y1 <- box_ymax - box_height * 0.15
-      text_y2 <- box_ymax - box_height * 0.5
-      text_y3 <- box_ymax - box_height * 0.85
-
-      train_val_plot <- ggplot(plot_data, aes(x = .data[[target_col]], y = .data[[target_pred_col]], color = group))+ #shape = collector)) +
-        geom_abline(intercept = 0, slope = 1, linetype = "dashed", size = 1.2) +
-
-        # Training points (all same shape)
-        geom_point(
-          data = filter(plot_data, group == "Train"),
-          #shape = 16,  # solid circle
-          size = 4,
-          alpha = 0.6) +
-        geom_point( # Testing points (shape by id)
-          data = filter(plot_data, group == "Validation"),
-          shape = 17,
-          #aes(shape = id),
-          size = 4,
-          alpha = 0.9
-        ) +
-        annotate("rect", xmin = box_xmin, xmax = box_xmax, ymin = box_ymin, ymax = box_ymax,
-                 fill = "white", color = "black", alpha = 1, linewidth = 0.5) +
-        annotate("text", x = text_x, y = text_y1, label = paste0("Training samples: n = ", (nrow(plot_data)- nrow(val_data))),
-                 color = "black", size = 3) +
-        annotate("text", x = text_x, y = text_y2, label = paste0("Validation samples: n = ", nrow(val_data)),
-                 color = "black", size = 3) +
-        annotate("text", x = text_x, y = text_y3, label = paste0("Val RMSE: ", val_rmse,
-                                                                 " ",units,", MAE:", val_mae, " ", units),
-                 color = "black", fontface = 2, size = 3.5) +
-        scale_color_manual(values = c("Train" = "#002EA3", "Validation" = "#FFCA3A")) +
-        #scale_shape_manual(values = c("ROSS" = 15, "FC" = 17, "Virridy" = 19)) +
-        labs(
-          x = paste0("Measured ", target_col, " (", units, ")"),
-          y = paste0("Predicted ", target_col, " (", units, ")"),
-          color = "Model Group",
-          #shape = "Site",
-          title = paste0("Model Fold: ", fold_id, " Grid: ", grid_id)
-        ) +
-        theme_bw(base_size = 16) +
-        xlim(min_val, max_val) +
-        ylim(min_val, max_val)
+      train_val_plot <- plot_tv_fold_perf(fold_set = fold_id, train_val_df = train_val_df, fold_model = fold_models[[model_key]],
+                                          target_col = "TOC", units = units)+
+        labs(title = paste("Fold", fold_id, "Grid", grid_id))
 
 #give one plot the legend
       if(k == 5){
@@ -409,9 +363,9 @@ xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "
       # Extract model and info
       model_obj <- fold_models[[model_key]]
       perf_row  <- best_rows[j, ]
-      params    <- model_obj[["params"]] %>%
-        as_tibble() %>%
-        select(-c(objective, eval_metric, validate_parameters))
+      params <- attributes(fold_models[[model_key]])$params
+      params <- params[!names(params) %in% c("objective", "eval_metric", "validate_parameters", "tree_method", "nthread", "seed")]%>%
+        as_tibble()
 
       # Store everything in a sub-list for this grid
       fold_results[[i]][["grid_results"]][[paste0("grid_", grid_id)]] <- list(
@@ -420,7 +374,7 @@ xgboost_hyperparameter_tuning <- function(data, target_col = "TOC", site_col = "
         params      = params
       )
     }
-    #clean up meemory
+    #clean up memory
     gc()
   }
 

--- a/src/plotting/plot_model_timeseries.R
+++ b/src/plotting/plot_model_timeseries.R
@@ -86,9 +86,13 @@ plot_model_timeseries <- function( model_input_df, water_chem_df, model, method 
     summarise(across(everything(), mean, na.rm = TRUE), .groups = 'drop')
 
   if(method  %in% c("Ensemble", "ensemble")){
+    features <- xgb.importance(model = model[[1]]) %>% pull(Feature)
+
+
     summarized_data <- imap_dfc(model, ~{
       # Get model features
-      features <- .x$feature_names
+      features <- xgb.importance(model = .x) %>% pull(Feature)
+      best_iter <- as.numeric(xgb.attr(.x, "best_iteration"))
 
       feature_data <- summarized_data %>%
         select(all_of(features)) %>%
@@ -99,7 +103,7 @@ plot_model_timeseries <- function( model_input_df, water_chem_df, model, method 
       # Make preds
       raw_preds <- feature_data %>%
         as.matrix() %>%
-        predict(.x, ., iteration_range = c(1, .x$best_iteration)) %>%
+        predict(.x, ., iteration_range = c(1, best_iter), validate_features = TRUE) %>%
         round(2)
 
       # make preds NA where features had NA
@@ -113,7 +117,7 @@ plot_model_timeseries <- function( model_input_df, water_chem_df, model, method 
       # compute ensemble mean
       mutate(
         !!glue("{target_col}_guess_ensemble") := if_else(
-          if_any(all_of(model[[1]]$feature_names), is.na),                # Check if ANY feature is NA
+          if_any(all_of(features), is.na),                # Check if ANY feature is NA
           NA_real_,                                                        # If true, set ensemble to NA
           round(rowMeans(across(matches(glue("{target_col}_guess_fold")))), 2) # Else, compute mean
         )
@@ -203,13 +207,14 @@ plot_model_timeseries <- function( model_input_df, water_chem_df, model, method 
       stop("For non-ensemble method, model must be a single trained model object.")
     }
 
-    features <- model$feature_names
+    features <- xgb.importance(model = model) %>% pull(Feature)
+    best_iter <- xgb.attr(model, "best_iteration")%>%as.numeric()
 
     preds <- summarized_data %>%
       select(all_of(features)) %>%
       mutate(across(everything(), as.numeric)) %>%
       as.matrix() %>%
-      predict(model, ., iteration_range = c(1, model$best_iteration)) %>%
+      predict(model, ., iteration_range = c(1, best_iter), validate_parameters = T) %>%
       round(2)
 
     plot_col <- glue("{target_col}_guess")
@@ -302,10 +307,11 @@ plot_model_timeseries <- function( model_input_df, water_chem_df, model, method 
   if(plot_model_input){
     if(method %in% c("Ensemble", "ensemble")){
       model <- model[[1]]  # Use the first model for input features
+      features <- xgb.importance(model = model) %>% pull(Feature)
     }
     # Plot model input data
     model_input_long <- summarized_data %>%
-      select(site, DT_round, all_of(model$feature_names)) %>%
+      select(site, DT_round, all_of(features)) %>%
       # Filter to desired time window first
       filter(between(DT_round, start_DT, end_DT)) %>%
       # Pad missing timestamps based on summary_interval

--- a/src/plotting/plot_train_test_ensemble_perf.R
+++ b/src/plotting/plot_train_test_ensemble_perf.R
@@ -60,8 +60,9 @@ plot_train_test_ensemble_perf <- function( train_val_df, test_df, fold_models, t
     # Make predictions with every fold
 
     test_preds_all <- map_dfc(fold_models, function(m) {
-      features <- m$feature_names
-      predict(m, as.matrix(test_df[, features]), iteration_range = c(1, m$best_iteration))
+      features <- xgb.importance(model = m) %>% pull(Feature)
+      best_iter <- as.numeric(xgb.attr(m, "best_iteration"))
+      predict(m, as.matrix(test_df[, features]), iteration_range = c(1, best_iter), validate_features = TRUE)
     })
     colnames(test_preds_all) <- paste0("fold_", seq_along(fold_models))
 
@@ -81,8 +82,9 @@ plot_train_test_ensemble_perf <- function( train_val_df, test_df, fold_models, t
 
     # --- Training predictions (mean across folds) ---
     train_preds_all <- map_dfc(fold_models, function(m) {
-      features <- m$feature_names
-      predict(m, as.matrix(train_val_df[, features]), iteration_range = c(1, m$best_iteration))
+      features <- xgb.importance(model = m) %>% pull(Feature)
+      best_iter <- as.numeric(xgb.attr(m, "best_iteration"))
+      predict(m, as.matrix(train_val_df[, features]), iteration_range = c(1, best_iter), validate_features = TRUE)
     })
     colnames(train_preds_all) <- paste0("fold_", seq_along(fold_models))
 

--- a/src/plotting/plot_tv_fold_perf.R
+++ b/src/plotting/plot_tv_fold_perf.R
@@ -60,12 +60,14 @@ plot_tv_fold_perf <- function(fold_set, train_val_df, fold_model, target_col = "
   source("src/setup_ross_theme.R") #load theme
 
   # Split data into training and validation sets based on fold_id
-  val_data <- train_val_df %>% filter(fold_set == fold_id)
+  val_data <- train_val_df %>% filter(fold_id == fold_set)
   train_data <- anti_join(train_val_df, val_data, by = "fold_id")
   # Create prediction column name
   target_pred_col <- paste0(target_col, "_guess")
   # Get model features
-  features <- fold_model$feature_names
+  features <- xgb.importance(model = fold_model)%>%pull(Feature)
+
+  best_iter <- as.numeric(xgb.attr(fold_model, "best_iteration"))
 
   #convert train_val sets to matrix for prediction
   val_matrix <- val_data[, features]%>%
@@ -75,10 +77,11 @@ plot_tv_fold_perf <- function(fold_set, train_val_df, fold_model, target_col = "
     mutate(across(everything(), as.numeric)) %>%
     as.matrix()
 
+
   #make predictions
-  val_data[[target_pred_col]] <-  predict(fold_model, val_matrix, iterationrange = c(1, fold_model$best_iteration))
+  val_data[[target_pred_col]] <-  predict(fold_model, val_matrix, iterationrange = c(1, best_iter), validate_features = T)
   val_data$group <-  "Validation"
-  train_data[[target_pred_col]] <-  predict(fold_model, train_matrix, iterationrange = c(1, fold_model$best_iteration))
+  train_data[[target_pred_col]] <-  predict(fold_model, train_matrix,  iterationrange = c(1,best_iter), validate_features = T)
   train_data$group <-  "Train"
 
   # Calculate RMSE/MAE for annotation & round to 3 decimals

--- a/src/plotting/plot_tvt_fold_perf.R
+++ b/src/plotting/plot_tvt_fold_perf.R
@@ -82,7 +82,8 @@ plot_tvt_fold_perf <- function( train_val_df, test_df, fold_set, fold_model, tar
   train_set <- anti_join(train_val_df, val_set, by = "id")
 
   #use the fold model to get feature names
-  features <- fold_model$feature_names
+  features <- xgb.importance(model = fold_model) %>% pull(Feature)
+  best_iter <- as.numeric(xgb.attr(fold_model, "best_iteration"))
   # Create matrix for train/val/test datasets
   val_matrix <- val_set[, features]%>%
     mutate(across(everything(), as.numeric)) %>%
@@ -97,13 +98,13 @@ plot_tvt_fold_perf <- function( train_val_df, test_df, fold_set, fold_model, tar
   pred_col <- glue("{target_col}_guess_fold{fold_set}")
 
   # make predictions
-  val_set[[pred_col]] <-  predict(fold_model, val_matrix, iterationrange = c(1, fold_model$best_iteration))
+  val_set[[pred_col]] <-  predict(fold_model, val_matrix, iterationrange = c(1, best_iter), validate_features = T)
   val_set$group <-  "Validation"
 
-  train_set[[pred_col]] <-  predict(fold_model, train_matrix, iterationrange = c(1, fold_model$best_iteration))
+  train_set[[pred_col]] <-  predict(fold_model, train_matrix, iterationrange = c(1, best_iter), validate_features = T)
   train_set$group <-  "Train"
 
-  test_df[[pred_col]] <-  predict(fold_model, test_matrix, iterationrange = c(1, fold_model$best_iteration))
+  test_df[[pred_col]] <-  predict(fold_model, test_matrix, iterationrange = c(1, best_iter), validate_features = T)
   test_df$group <-  "Test"
 
 


### PR DESCRIPTION
Hi @steeleb , 
Mostly minor troubleshooting to get our training/model application functions to work with the new XGboost version. I rerendered the `toc_model_live_2025` html to the docs folder if you want to look that over but model results did not change (yay!). 

The main differences in the xgb update are:
- You cannot acccess model$feature _names or model$best_iteration in the same way
- The model expects features to be in the same order as training unless you add `validate_features = T` to the `predict()` call
- We save the files as `.ubj` files instead of RDS in case there are future updates to the package

I also simplified the hyperparameter tune function to just look for `fold_id` and split data into train vs val that way

I have also opened an issue to apply these updates to our categorical model functions but am back burnering it since we aren't using those models currently